### PR TITLE
Backend: Deployment to Google Cloud Run

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,29 +1,80 @@
-FROM ubuntu:22.04
-RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y nginx php-fpm php-curl php-xml php-pgsql composer supervisor nano && \
-    rm -rf /var/lib/apt/lists/
+# Step 1: Install dependencies
+#
+# https://hub.docker.com/_/composer
+#
+FROM composer:2 as build
 
-COPY docker/php/docker-entrypoint.sh /usr/local/bin/docker-entrypoint
-COPY docker/php/docker-healthcheck.sh /usr/local/bin/docker-healthcheck
-RUN chmod +x /usr/local/bin/docker-healthcheck /usr/local/bin/docker-entrypoint && \
-    echo "clear_env = no" >> /etc/php/8.1/fpm/pool.d/www.conf
+WORKDIR /app/
+COPY . /app/
 
-COPY docker/nginx.conf /etc/nginx/nginx.conf
-COPY docker/supervisord.conf /etc/supervisor/conf.d/app.conf
-COPY docker/php/conf.d/symfony.prod.ini /etc/php/8.1/fpm/conf.d/symfony.ini
+RUN apk add --no-cache icu-dev postgresql-dev \
+    && install-php-extensions intl \
+    && install-php-extensions pgsql \
+    && install-php-extensions pdo pdo_pgsql \
+    && install-php-extensions opcache
 
-COPY . /var/www/html/
+RUN composer install --no-dev --no-interaction \
+    && composer dump-autoload --optimize --no-dev \
+    && composer symfony:dump-env prod
+
+
+# Step 2: Deploy application
+#
+# https://github.com/docker-library/docs/blob/master/php/README.md#phpversion-apache
+#
+FROM php:8.1-apache
+
+RUN apt-get update \
+    && apt-get install -y acl libicu-dev libpq-dev g++ \
+    && rm -rf /var/lib/apt/lists/*
+RUN docker-php-ext-configure intl \
+    && docker-php-ext-install \
+        intl \
+        pdo \
+        pdo_pgsql \
+        pgsql
+
+# https://cloud.google.com/run/docs/quickstarts/build-and-deploy/deploy-php-service
+#
+RUN docker-php-ext-install -j "$(nproc)" opcache
+
+RUN set -ex; \
+  { \
+    echo "; Cloud Run enforces memory & timeouts"; \
+    echo "memory_limit = -1"; \
+    echo "max_execution_time = 0"; \
+    echo "; File upload at Cloud Run network limit"; \
+    echo "upload_max_filesize = 32M"; \
+    echo "post_max_size = 32M"; \
+    echo "; Configure Opcache for Containers"; \
+    echo "opcache.enable = On"; \
+    echo "opcache.validate_timestamps = Off"; \
+    echo "; Configure Opcache Memory (Application-specific)"; \
+    echo "opcache.memory_consumption = 32"; \
+  } > "$PHP_INI_DIR/conf.d/cloud-run.ini"
+
 WORKDIR /var/www/html
 
-RUN set -eux; \
-	mkdir -p var/cache var/log; \
-	composer install --prefer-dist --no-dev --no-progress --no-interaction; \
-	composer dump-autoload --optimize --no-dev; \
-	composer symfony:dump-env prod; \
-	chmod +x bin/console; \
-  sync
+ENV APP_ENV=prod
+ENV HTTPDUSER='www-data'
 
-#HEALTHCHECK --interval=10s --timeout=3s --retries=3 CMD ["docker-healthcheck"]
-ENTRYPOINT ["docker-entrypoint"]
-EXPOSE 8080/tcp
-CMD ["supervisord", "--nodaemon"]
+EXPOSE 8080
+
+COPY docker/apache.conf /etc/apache2/sites-available/000-default.conf
+COPY --from=build /app /var/www/html/
+
+RUN setfacl -dR -m u:"$HTTPDUSER":rwX -m u:$(whoami):rwX /var && \
+    setfacl -R -m u:"$HTTPDUSER":rwX -m u:$(whoami):rwX /var && \
+    echo "Listen 8080" >> /etc/apache2/ports.conf && \
+    mkdir -p /var/www/html/var/log/ && \
+    mkdir -p /var/www/html/var/cache/ && \
+    usermod -u 1000 www-data && \
+    chown -R www-data:www-data /var/www/ && \
+    a2enmod rewrite
+
+USER www-data
+
+RUN php bin/console cache:clear --no-warmup \
+    && php bin/console cache:warmup
+
+CMD ["apache2-foreground"]

--- a/backend/composer.json
+++ b/backend/composer.json
@@ -32,8 +32,7 @@
     "scripts": {
         "auto-scripts": {
             "cache:clear --env=prod --no-debug": "symfony-cmd",
-            "assets:install --env=prod --symlink --relative %PUBLIC_DIR%": "symfony-cmd",
-            "doctrine:migrations:migrate --no-interaction --env=prod": "symfony-cmd"
+            "assets:install --env=prod --symlink --relative %PUBLIC_DIR%": "symfony-cmd"
         },
         "post-install-cmd": [
             "@auto-scripts"

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -4,7 +4,12 @@ services:
       context: .
     environment:
       # Run "composer require symfony/orm-pack" to install and configure Doctrine ORM
-      DATABASE_URL: postgresql://${POSTGRES_USER:-symfony}:${POSTGRES_PASSWORD:-ChangeMe}@database:5432/${POSTGRES_DB:-app}?serverVersion=${POSTGRES_VERSION:-13}
+      DB_HOST: database
+      DB_PORT: 5432
+      DB_USER: ${POSTGRES_USER:-symfony}
+      DB_PASSWORD: ${POSTGRES_PASSWORD:-ChangeMe}
+      DB_DBNAME: ${POSTGRES_DB:-app}
+      DB_VERSION: ${POSTGRES_VERSION:-13}
     restart: unless-stopped
     ports:
       # HTTP

--- a/backend/docker/apache.conf
+++ b/backend/docker/apache.conf
@@ -1,0 +1,35 @@
+<VirtualHost *:8080>
+    ServerName admin.mistoveskole.cz
+
+    DocumentRoot /var/www/html/public
+    <Directory /var/www/html/public>
+        AllowOverride None
+        Order Allow,Deny
+        Allow from All
+
+        <IfModule mod_rewrite.c>
+            Options -MultiViews
+            RewriteEngine On
+            RewriteCond %{REQUEST_FILENAME} !-f
+            RewriteRule ^(.*)$ index.php [QSA,L]
+        </IfModule>
+    </Directory>
+
+    # uncomment the following lines if you install assets as symlinks
+    # or run into problems when compiling LESS/Sass/CoffeeScript assets
+    # <Directory /var/www/html>
+    #     Options FollowSymlinks
+    # </Directory>
+
+    # optionally disable the RewriteEngine for the asset directories
+    # which will allow apache to simply reply with a 404 when files are
+    # not found instead of passing the request into the full symfony stack
+    <Directory /var/www/html/public/bundles>
+        <IfModule mod_rewrite.c>
+            RewriteEngine Off
+        </IfModule>
+    </Directory>
+    #ErrorLog /var/log/apache2/project_error.log
+    #CustomLog /var/log/apache2/project_access.log combined
+    PassEnv APP_ENV
+</VirtualHost>


### PR DESCRIPTION
This patch makes changes to the Docker configuration, in order to run the service in Google Cloud Run environment (see [documentation](https://cloud.google.com/run/docs/quickstarts/build-and-deploy/deploy-php-service)). It uses the [`php:8.1-apache`](https://github.com/docker-library/docs/blob/master/php/README.md#phpversion-apache) official Docker image.

The `composer.json` configuration has been updated to skip running migrations, as the database might not be available during the build step. Migrations should be run during the Cloud Build process, after the image is built.