### PR TITLE
Add Terrafrom configuration for deployment in GCP

### DIFF
--- a/infrastructure/.gitignore
+++ b/infrastructure/.gitignore
@@ -1,0 +1,4 @@
+.terraform/
+tmp/
+
+gcp/.terraform*

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -1,0 +1,175 @@
+# Infrastructure
+
+This folder contains code and resources to create infrastructure for the project
+in [Google Cloud Platform (GCP)](https://cloud.google.com) with
+[_Terraform_](https://www.terraform.io).
+
+The code expects a project in GCP, *with billing enabled*.
+
+Navigate to the `gcp` folder:
+
+```
+cd gcp/
+```
+
+Export the environment variables with information about the project and the application.
+
+```
+export PROJECT_ID=mistoveskole-tf-3
+export USER_EMAIL=your.email@cesko.digital
+export SERVICE_ACCOUNT_NAME=terraform-3
+export DATABASE_PASSWORD=ABC123XXXXXXXXXXXXXXXXXXXXXXXX
+```
+
+Then, configure the [`gcloud`](https://cloud.google.com/sdk/gcloud)
+utility to use the project:
+
+```
+gcloud config set project $PROJECT_ID
+```
+
+Enable the required services:
+
+```
+gcloud services enable \
+  compute.googleapis.com \
+  containerregistry.googleapis.com \
+  cloudbilling.googleapis.com \
+  cloudbuild.googleapis.com \
+  cloudresourcemanager.googleapis.com \
+  iam.googleapis.com \
+  logging.googleapis.com \
+  run.googleapis.com \
+  servicenetworking.googleapis.com \
+  sql-component.googleapis.com \
+  sqladmin.googleapis.com \
+  storage.googleapis.com \
+  vpcaccess.googleapis.com
+```
+
+**Important**: Connect the Github repository to Cloud Build via the web console, following the [documentation](https://cloud.google.com/build/docs/automating-builds/build-repos-from-github).
+
+Next, get the number of the project:
+
+```
+gcloud projects describe $PROJECT_ID
+> ...
+> projectId: $PROJECT_ID
+> projectNumber: '123456789'
+
+export PROJECT_NUMBER=123456789
+```
+
+Then, add permissions for Cloud Build to access Cloud Run:
+
+```
+gcloud projects add-iam-policy-binding $PROJECT_ID \
+    --member="serviceAccount:$PROJECT_NUMBER@cloudbuild.gserviceaccount.com" \
+    --role="roles/run.admin"
+```
+
+Add permissions for Cloud Build to use service accounts:
+
+```
+gcloud projects add-iam-policy-binding $PROJECT_ID \
+    --member="serviceAccount:$PROJECT_NUMBER@cloudbuild.gserviceaccount.com" \
+    --role="roles/iam.serviceAccountUser"
+```
+
+Add permissions for the default service account to access Cloud SQL:
+
+```
+gcloud projects add-iam-policy-binding $PROJECT_ID \
+    --member="serviceAccount:$PROJECT_NUMBER-compute@developer.gserviceaccount.com" \
+    --role="roles/cloudsql.client"
+```
+
+Add permissions for the default service account to access Cloud Run:
+
+```
+gcloud projects add-iam-policy-binding $PROJECT_ID \
+    --member="serviceAccount:$PROJECT_NUMBER-compute@developer.gserviceaccount.com" \
+    --role="roles/run.admin"
+```
+
+Create a service account with appropriate permissions:
+
+```
+gcloud iam service-accounts create $SERVICE_ACCOUNT_NAME --display-name="$SERVICE_ACCOUNT_NAME"
+
+gcloud iam service-accounts add-iam-policy-binding \
+    $SERVICE_ACCOUNT_NAME@$PROJECT_ID.iam.gserviceaccount.com \
+    --member="user:$USER_EMAIL" \
+    --role="roles/iam.serviceAccountUser"
+
+gcloud projects add-iam-policy-binding $PROJECT_ID \
+    --member="serviceAccount:$SERVICE_ACCOUNT_NAME@$PROJECT_ID.iam.gserviceaccount.com" \
+    --role="roles/owner" \
+
+gcloud projects add-iam-policy-binding $PROJECT_ID \
+    --member="serviceAccount:$SERVICE_ACCOUNT_NAME@$PROJECT_ID.iam.gserviceaccount.com" \
+    --role="roles/compute.admin"
+
+gcloud projects add-iam-policy-binding $PROJECT_ID \
+    --member="serviceAccount:$SERVICE_ACCOUNT_NAME@$PROJECT_ID.iam.gserviceaccount.com" \
+    --role="roles/storage.admin"
+
+gcloud projects add-iam-policy-binding $PROJECT_ID \
+    --member="serviceAccount:$SERVICE_ACCOUNT_NAME@$PROJECT_ID.iam.gserviceaccount.com" \
+    --role="roles/run.admin"
+
+gcloud projects add-iam-policy-binding $PROJECT_ID \
+    --member="serviceAccount:$SERVICE_ACCOUNT_NAME@$PROJECT_ID.iam.gserviceaccount.com" \
+    --role="roles/cloudsql.client"
+```
+
+Then, create and download access keys for Terraform:
+
+```
+gcloud iam service-accounts keys create ../tmp/gcp-key-$SERVICE_ACCOUNT_NAME.json --iam-account="$SERVICE_ACCOUNT_NAME@$PROJECT_ID.iam.gserviceaccount.com"
+```
+
+Export the path as an
+[environment variable](https://cloud.google.com/docs/authentication/production#passing_variable):
+
+```
+export GOOGLE_APPLICATION_CREDENTIALS=../tmp/gcp-key-$SERVICE_ACCOUNT_NAME.json
+```
+
+Create a Google Cloud Storage (GCS) bucket for storing the Terraform state:
+
+```
+gsutil mb -p $PROJECT_ID -l europe-west1 -b on gs://cesko-digital-terraform-$PROJECT_ID
+```
+
+Install required providers and initialize the configuration:
+
+```
+terraform init
+```
+
+Preview the infrastructure to be created ("dry-run"):
+
+```
+TF_VAR_database_password=$DATABASE_PASSWORD terraform plan
+```
+
+Create the infrastructure:
+
+```
+TF_VAR_database_password=$DATABASE_PASSWORD terraform apply
+```
+
+After the initial run, create the database in PostgreSQL:
+
+```
+gcloud sql databases create mistoveskole --instance=mistoveskole-db
+```
+
+Then, trigger the Cloud Build to build the image with the application:
+
+```
+gcloud beta builds triggers run backend --branch=deployment
+```
+
+The trigger should update the application image and deploy the current revision.

--- a/infrastructure/gcp/application.tf
+++ b/infrastructure/gcp/application.tf
@@ -1,0 +1,72 @@
+data "google_iam_policy" "public_access" {
+  binding {
+    role    = "roles/run.invoker"
+    members = ["allUsers"]
+  }
+}
+
+resource "google_cloud_run_service_iam_policy" "public_access" {
+  location = var.cloud_region
+  project  = var.project_name
+  service  = google_cloud_run_service.backend.name
+
+  policy_data = data.google_iam_policy.public_access.policy_data
+}
+
+resource "google_cloud_run_service" "backend" {
+  name     = var.application_name
+  location = var.cloud_region
+
+  template {
+    spec {
+      containers {
+        # This image is only for initial deployment, before the application image
+        # is built and pushed to the registry. The real URL is:
+        # "eu.gcr.io/${var.project_name}/${var.application_name}/backend:$COMMIT"
+        image = "us-docker.pkg.dev/cloudrun/container/hello"
+        ports {
+          container_port = 8080
+        }
+        env {
+          name = "DB_HOST"
+          value = "/cloudsql/${google_sql_database_instance.database.connection_name}"
+        }
+        env {
+          name = "DB_USER"
+          value = "postgres"
+        }
+        env {
+          name = "DB_PASSWORD"
+          value = var.database_password
+        }
+        env {
+          name = "DB_DBNAME"
+          value = "mistoveskole"
+        }
+        env {
+          name = "DB_VERSION"
+          value = "13"
+        }
+      }
+    }
+
+    metadata {
+      annotations = {
+        "autoscaling.knative.dev/maxScale"      = "100"
+        "run.googleapis.com/cloudsql-instances" = google_sql_database_instance.database.connection_name
+        "run.googleapis.com/client-name"        = "terraform"
+      }
+    }
+  }
+
+  autogenerate_revision_name = true
+}
+
+# resource "google_cloud_run_domain_mapping" "app" {
+#   location = var.cloud_region
+#   name     = "admin.mistoveskole.cz"
+
+#   metadata { namespace = "admin.mistoveskole.cz" }
+
+#   spec { route_name = google_cloud_run_service.backend.name }
+# }

--- a/infrastructure/gcp/build.tf
+++ b/infrastructure/gcp/build.tf
@@ -1,0 +1,56 @@
+# resource "google_storage_bucket" "artifacts" {
+#   location                 = "EU"
+#   name                     = "eu.artifacts.mistoveskole.appspot.com"
+#   project                  = var.project_name
+#   public_access_prevention = "inherited"
+#   storage_class            = "STANDARD"
+# }
+
+resource "google_container_registry" "container_registry" {
+  project  = var.project_name
+  location = "EU"
+}
+
+# NOTE: You need to connect Cloud Build to the Github first,
+#       https://cloud.google.com/build/docs/automating-builds/build-repos-from-github#installing_gcb_app.
+
+resource "google_cloudbuild_trigger" "backend" {
+  name = "backend"
+
+  github {
+    owner = "cesko-digital"
+    name  = "mistoveskole"
+
+    push {
+      branch = var.application_deploy_branch
+    }
+  }
+
+  build {
+    step {
+      id   = "Build"
+      name = "gcr.io/cloud-builders/docker"
+      args = ["build", "--no-cache", "-t", "$_GCR_BASE_PATH:$SHORT_SHA", "backend", "-f", "backend/Dockerfile"]
+    }
+
+    step {
+      id   = "Push Commit"
+      name = "gcr.io/cloud-builders/docker"
+      args = ["push", "$_GCR_BASE_PATH:$SHORT_SHA"]
+    }
+
+    step {
+      id         = "Deploy"
+      name       = "gcr.io/google.com/cloudsdktool/cloud-sdk:slim"
+      entrypoint = "gcloud"
+      args       = ["run", "services", "update", "$_SERVICE_NAME", "--platform=managed", "--image=$_GCR_BASE_PATH:$SHORT_SHA", "--region=${var.cloud_region}", "--quiet"]
+    }
+
+    timeout = "1200s"
+  }
+
+  substitutions = {
+    _GCR_BASE_PATH = "eu.gcr.io/${var.project_name}/${var.application_name}/backend"
+    _SERVICE_NAME  = google_cloud_run_service.backend.name
+  }
+}

--- a/infrastructure/gcp/database.tf
+++ b/infrastructure/gcp/database.tf
@@ -1,0 +1,39 @@
+resource "google_sql_database_instance" "database" {
+  name                = "mistoveskole-db"
+  region              = var.cloud_region
+  database_version    = "POSTGRES_13"
+  deletion_protection = false
+
+  settings {
+    tier = var.database_instance_type
+
+    activation_policy = "ALWAYS"
+    availability_type = "ZONAL"
+
+    backup_configuration {
+      backup_retention_settings {
+        retained_backups = 7
+        retention_unit   = "COUNT"
+      }
+
+      enabled                        = true
+      location                       = "eu"
+      point_in_time_recovery_enabled = true
+      transaction_log_retention_days = 7
+    }
+
+    disk_autoresize       = true
+    disk_autoresize_limit = 0
+    disk_size             = 20
+    disk_type             = "PD_SSD"
+
+    ip_configuration {
+      ipv4_enabled    = true
+    }
+
+    insights_config {
+      query_insights_enabled = true
+      query_string_length    = 1024
+    }
+  }
+}

--- a/infrastructure/gcp/main.tf
+++ b/infrastructure/gcp/main.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_version = ">= 1.1"
+
+  backend "gcs" {
+    bucket = "cesko-digital-terraform-mistoveskole-tf-3"
+    prefix = "tf-state"
+  }
+}
+
+provider "google" {
+  project = var.project_name
+  region  = var.cloud_region
+}

--- a/infrastructure/gcp/network.tf
+++ b/infrastructure/gcp/network.tf
@@ -1,0 +1,62 @@
+resource "google_compute_network" "default" {
+  name                    = "default"
+  description             = "Default network"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "default" {
+  name          = "default"
+  ip_cidr_range = "10.0.0.0/22"
+  region        = var.cloud_region
+  network       = google_compute_network.default.self_link
+}
+
+resource "google_compute_firewall" "allow-ssh" {
+  name        = "${google_compute_network.default.name}-allow-ssh"
+  description = "Allow SSH from external"
+  network     = google_compute_network.default.self_link
+
+  allow {
+    protocol = "tcp"
+    ports    = ["22"]
+  }
+
+  source_ranges = ["0.0.0.0/0"]
+  target_tags   = ["allow-ssh"]
+}
+
+resource "google_compute_firewall" "allow-https" {
+  name        = "${google_compute_network.default.name}-allow-https"
+  description = "Allow HTTPS from external"
+  network     = google_compute_network.default.self_link
+
+  allow {
+    protocol = "tcp"
+    ports    = ["443"]
+  }
+
+  source_ranges = ["0.0.0.0/0"]
+  target_tags   = ["allow-https"]
+}
+
+resource "google_compute_firewall" "allow-internal" {
+  allow {
+    protocol = "tcp"
+    ports    = ["0-65535"]
+  }
+
+  allow {
+    protocol = "udp"
+    ports    = ["0-65535"]
+  }
+
+  allow {
+    protocol = "icmp"
+  }
+
+  description   = "Allow internal traffic"
+  direction     = "INGRESS"
+  name          = "allow-internal"
+  network       = google_compute_network.default.self_link
+  source_ranges = ["10.0.0.0/22"]
+}

--- a/infrastructure/gcp/outputs.tf
+++ b/infrastructure/gcp/outputs.tf
@@ -1,0 +1,27 @@
+output "project_name" {
+  value = var.project_name
+}
+
+output "application_name" {
+  value = var.application_name
+}
+
+output "deploy_branch" {
+  value = var.application_deploy_branch
+}
+
+output "database_public_ip" {
+  value = google_sql_database_instance.database.public_ip_address
+}
+
+output "database_connection_name" {
+  value = google_sql_database_instance.database.connection_name
+}
+
+output "build_trigger_id" {
+  value = google_cloudbuild_trigger.backend.trigger_id
+}
+
+output "cloud_run_url" {
+  value = one(google_cloud_run_service.backend.status[*].url)
+}

--- a/infrastructure/gcp/variables.tf
+++ b/infrastructure/gcp/variables.tf
@@ -1,0 +1,41 @@
+variable "project_name" {
+  description = "The ID of the project"
+  default     = "mistoveskole-tf-3"
+}
+
+variable "application_name" {
+  description = "Name of the application - must be unique in region"
+  default     = "mistoveskole-v3"
+}
+
+variable "application_deploy_branch" {
+  description = "GitHub branch to deploy"
+  default     = "deployment"
+}
+
+variable "database_name" {
+  description = "Name of the database"
+  default     = "mistoveskole"
+}
+
+variable "cloud_region" {
+  description = "The GCP region where to create resources"
+  default     = "europe-west1"
+}
+
+variable "database_instance_type" {
+  description = "Type of the Cloud SQL instance"
+  default     = "db-f1-micro"
+}
+
+variable "database_password" {
+  type        = string
+  description = "Main password for database"
+  nullable    = false
+  sensitive   = true
+
+  validation {
+    condition     = length(var.database_password) >= 30
+    error_message = "The password must be at least 30 character long."
+  }
+}


### PR DESCRIPTION
This patch adds the configuration for deploying the service in Google Cloud Platform. It needs https://github.com/cesko-digital/mistoveskole/pull/8 to be merged first.