### PR TITLE
feat: port styleguide colors to tailwind

### DIFF
--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,3 +1,8 @@
+const { default: colors } = require('./tailwind/colors');
+const textColor = require('./tailwind/textColor');
+const borderColor = require('./tailwind/borderColor');
+const backgroundColor = require('./tailwind/backgroundColor');
+
 module.exports = {
   content: [
     './components/**/*.{js,vue,ts}',
@@ -11,7 +16,12 @@ module.exports = {
     container: {
       center: true,
     },
-    extend: {},
+    colors,
+    extend: {
+      textColor,
+      borderColor,
+      backgroundColor,
+    },
   },
   plugins: [
     require('@tailwindcss/forms'),

--- a/frontend/tailwind/backgroundColor.js
+++ b/frontend/tailwind/backgroundColor.js
@@ -1,0 +1,20 @@
+const { neutral, primary, secondary, danger, success } = require('./colors');
+
+module.exports = {
+  DEFAULT: neutral[90],
+  muted: neutral[80],
+
+  btn: {
+    primary: {
+      DEFAULT: primary[50],
+      hover: primary[40],
+      active: primary[60],
+      disabled: primary[80],
+    },
+  },
+
+  info: primary[80],
+  warning: secondary[80],
+  danger: danger[80],
+  success: success[80],
+};

--- a/frontend/tailwind/borderColor.js
+++ b/frontend/tailwind/borderColor.js
@@ -1,0 +1,6 @@
+const { neutral, primary } = require('./colors');
+
+module.exports = {
+  DEFAULT: neutral[70],
+  active: primary[50],
+};

--- a/frontend/tailwind/colors.js
+++ b/frontend/tailwind/colors.js
@@ -1,0 +1,63 @@
+const primary = {
+  80: '#CFF5FF',
+  70: '#84E3FF',
+  60: '#3FC1FF',
+  50: '#0D97FB',
+  40: '#086BBF',
+  30: '#094081',
+  10: '#091D4D',
+};
+
+const neutral = {
+  90: '#FFFFFF',
+  80: '#E2EEF6',
+  70: '#D1E7F1',
+  60: '#B5D4E0',
+  50: '#92B4C2',
+  40: '#677E8F',
+  30: '#47525E',
+  10: '#262729',
+  0: '#000000',
+};
+
+const secondary = {
+  80: '#FFFCCB',
+  70: '#F9FF8C',
+  60: '#FBFF49',
+  50: '#FFE70D',
+  40: '#D2A003',
+  30: '#8A5506',
+  10: '#331405',
+};
+
+const success = {
+  80: '#CAEFC0',
+  60: '#8BD86A',
+  50: '#56BC27',
+  30: '#257E10',
+  10: '#052E06',
+};
+
+const danger = {
+  80: '#F6C2C1',
+  60: '#F2717B',
+  50: '#E02F3F',
+  30: '#9B1A27',
+  10: '#330B0B',
+};
+
+module.exports = {
+  primary,
+  neutral,
+  secondary,
+  success,
+  danger,
+
+  default: {
+    inherit: 'inherit',
+    current: 'currentColor',
+    transparent: 'transparent',
+    black: '#000',
+    white: '#fff',
+  },
+}

--- a/frontend/tailwind/textColor.js
+++ b/frontend/tailwind/textColor.js
@@ -8,7 +8,7 @@ module.exports = {
   info: primary[10],
   warning: secondary[10],
   danger: danger[10],
-  succes: success[10],
+  success: success[10],
 
   icon: {
     DEFAULT: neutral[10],

--- a/frontend/tailwind/textColor.js
+++ b/frontend/tailwind/textColor.js
@@ -1,0 +1,52 @@
+const { neutral, primary, secondary, danger, success } = require('./colors');
+
+module.exports = {
+  DEFAULT: neutral[30],
+  strong: neutral[10],
+  muted: neutral[40],
+
+  info: primary[10],
+  warning: secondary[10],
+  danger: danger[10],
+  succes: success[10],
+
+  icon: {
+    DEFAULT: neutral[10],
+    muted: neutral[50],
+    circle: primary[50],
+
+    info: primary[40],
+    warning: secondary[40],
+    danger: danger[40],
+    success: success[40],
+  },
+
+  link: {
+    DEFAULT: primary[50],
+    hover: primary[40],
+    active: primary[50],
+    disabled: primary[80],
+
+    info: {
+      DEFAULT: primary[30],
+      hover: primary[10],
+    },
+
+    warning: {
+      DEFAULT: secondary[30],
+      hover: secondary[10],
+    },
+
+    danger: {
+      DEFAULT: danger[30],
+      hover: danger[10],
+    },
+
+    success: {
+      DEFAULT: success[30],
+      hover: success[10],
+    },
+  },
+
+  'on-color': neutral[90],
+};


### PR DESCRIPTION
Can be previewed on `/_tailwind/` **(only locally)**

Styleguide:

![image](https://user-images.githubusercontent.com/2855777/170531273-9066cf80-a804-47d6-883d-2b0514e1f1f5.png)

Tailwind:

![image](https://user-images.githubusercontent.com/2855777/170552193-076c84e0-d89e-404f-83ca-203d4593b973.png)
![image](https://user-images.githubusercontent.com/2855777/170552215-60acad73-6c7e-40d4-8e01-444786e925fa.png)
![image](https://user-images.githubusercontent.com/2855777/170552237-03a7b25b-9e5c-4b46-8b78-036687fa4f1a.png)
